### PR TITLE
fix: receipt crash, phone format, amount type, empty receipt

### DIFF
--- a/packages/medusa-payment-yookassa/src/providers/payment-yookassa/core/yookassa-base.ts
+++ b/packages/medusa-payment-yookassa/src/providers/payment-yookassa/core/yookassa-base.ts
@@ -157,7 +157,7 @@ abstract class YookassaBase extends AbstractPaymentProvider<YookassaOptions> {
     const receiptTemplate = buildReceiptTemplate(receipt)
     const createPayload: ICreatePayment = {
       amount: {
-        value: amount as string,
+        value: String(Number(amount).toFixed(2)),
         currency: currency_code.toUpperCase(), // Medusa stores currency codes in lower case of ISO-4217
       },
       metadata: {
@@ -165,7 +165,7 @@ abstract class YookassaBase extends AbstractPaymentProvider<YookassaOptions> {
         receip_tmp: receiptTemplate
       },
       ...additionalParameters,
-      ...(this.options_.useReceipt ? { receipt: receipt } : {}),
+      ...(this.options_.useReceipt && receipt?.items?.length ? { receipt: receipt } : {}),
     }
 
     try {

--- a/packages/medusa-payment-yookassa/src/providers/payment-yookassa/utils/build-receipt-template.ts
+++ b/packages/medusa-payment-yookassa/src/providers/payment-yookassa/utils/build-receipt-template.ts
@@ -2,6 +2,9 @@ import { IReceipt } from "@a2seven/yoo-checkout"
 
 export function buildReceiptTemplate(receipt: IReceipt) {
   const firstItem = receipt.items?.[0]
+  if (!firstItem || !firstItem.amount) {
+    return "{}"
+  }
   const tpl = {
     cur: firstItem.amount.currency,
     vat: firstItem?.vat_code,

--- a/packages/medusa-payment-yookassa/src/providers/payment-yookassa/utils/generate-receipt.ts
+++ b/packages/medusa-payment-yookassa/src/providers/payment-yookassa/utils/generate-receipt.ts
@@ -19,7 +19,8 @@ export function generateReceipt(
 ): IReceipt {
 
   const email = cart?.email as string
-  const phone = cart?.shipping_address.phone as string
+  const rawPhone = cart?.shipping_address.phone as string
+  const phone = rawPhone?.replace(/[^\d+]/g, "")
   const items = cart?.items as Array<Record<string, any>>
   const currencyCode = cart?.currency_code as string
   const shippingTotal = cart?.shipping_total as number


### PR DESCRIPTION
Fixes #10

## Summary

Four bugs that cause `400 invalid_request` errors from YooKassa API when creating payments.

---

### 1. `amount.value` must be a string, not a number

**File:** `yookassa-base.ts:160`

The current code passes `amount` as-is (a number from Medusa). YooKassa API requires `amount.value` to be a **string** in `"XXXX.XX"` format.

**Evidence:** [YooKassa API docs — Create Payment](https://yookassa.ru/developers/api#create_payment) specify:

> `amount.value` — string, required. The amount value. Always a string with a dot separator, e.g. `"100.00"`.

**Error:** `400 invalid_request - Invalid request parameter`

**Fix:** `String(Number(amount).toFixed(2))`

---

### 2. `receipt.customer.phone` must contain only digits

**File:** `generate-receipt.ts:22`

The plugin passes `cart.shipping_address.phone` directly into the receipt. If the phone contains formatting characters (e.g. `"+7 (977) 605-93-28"`), YooKassa rejects it.

**Evidence:** [YooKassa API docs — Receipt object](https://yookassa.ru/developers/api#create_payment) specify:

> `receipt.customer.phone` — Phone number in ITU-T E.164 format. E.g. `"+79000000000"`.

**Error:** `400 invalid_request - Invalid request parameter` with `"parameter": "receipt.customer.phone"`

**Fix:** `phone?.replace(/[^\d+]/g, "")`

---

### 3. `buildReceiptTemplate` crashes on empty receipt

**File:** `build-receipt-template.ts:4-6`

When `useReceipt: true` but `data.cart` is not provided by Medusa (e.g. the cart is not included in the payment session data), `receipt` is `{}` and `receipt.items?.[0]` is `undefined`. The next line `firstItem.amount.currency` throws:

```
TypeError: Cannot read properties of undefined (reading 'amount')
```

**Fix:** Add early return when `firstItem` is missing.

---

### 4. Empty `receipt: {}` sent in payload

**File:** `yookassa-base.ts:168`

When `useReceipt: true` but no cart is available, the receipt is `{}` (empty object). The current code still includes it in the payload as `"receipt": {}`. YooKassa rejects this.

**Error:** `400 invalid_request - Invalid request parameter`

**Fix:** Check `receipt?.items?.length` before including receipt in the payload.

---

## Testing

All four fixes have been verified in production against YooKassa test environment (shop ID `1155122`). Payments create successfully after applying these changes.